### PR TITLE
[ch18860] WC 3.8 compatibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: skyverge, maxrice, tamarazuk, chasewiseman, nekojira, beka.rice
 Tags: woocommerce, product tabs, custom tab, woo commerce tab
 Requires at least: 4.4
 Tested up to: 5.2.2
-Stable tag: 1.7.0
+Stable tag: 1.7.1-dev.1
 
 This plugin extends WooCommerce by allowing a custom product tab to be created with any content.
 
@@ -79,6 +79,9 @@ add_filter( 'woocommerce_custom_product_tabs_lite_title', 'sv_change_custom_tab_
 `
 
 == Changelog ==
+
+= 2019.nn.nn - version 1.7.1-dev.1 =
+ * Misc - Add support for WooCommerce 3.8
 
 = 2019.08.15 - version 1.7.0
  * Misc - Add support for WooCommerce 3.7

--- a/woocommerce-custom-product-tabs-lite.php
+++ b/woocommerce-custom-product-tabs-lite.php
@@ -5,7 +5,7 @@
  * Description: Extends WooCommerce to add a custom product view page tab
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 1.7.0
+ * Version: 1.7.1-dev.1
  * Tested up to: 5.2.2
  * Text Domain: woocommerce-custom-product-tabs-lite
  * Domain Path: /i18n/languages/
@@ -20,7 +20,7 @@
  * @license     http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 3.0.9
- * WC tested up to: 3.7.0
+ * WC tested up to: 3.8.0
  */
 
 defined( 'ABSPATH' ) or exit;
@@ -40,7 +40,7 @@ class WooCommerceCustomProductTabsLite {
 
 
 	/** plugin version number */
-	const VERSION = '1.7.0';
+	const VERSION = '1.7.1-dev.1';
 
 	/** required WooCommerce version number */
 	const MIN_WOOCOMMERCE_VERSION = '3.0.9';


### PR DESCRIPTION
# Summary

This release adds support for WC 3.8.

### Stories

- [CH 18860](https://app.clubhouse.io/skyverge/story/18860)

## Details

Custom Product Tabs Lite doesn't use the framework, so this is just a version bump & wc-tested-to bump.

## QA

- Activate WC Admin
- Activate Custom Product Tabs Lite
- Add a custom tab to a product
- [x] Custom Product Tabs Settings save correctly
- [x] Custom Product Tab is displayed correctly on frontend

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version