### PR TITLE
Custom Product Tabs Lite: WC 3.9 Compatibility Release

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,9 @@ add_filter( 'woocommerce_custom_product_tabs_lite_title', 'sv_change_custom_tab_
 
 == Changelog ==
 
+= 2020.nn.nn - version 1.7.2-dev.1 =
+ * Misc - Add support for WooCommerce 3.9
+
 = 2019.11.11 - version 1.7.1 =
  * Misc - Add support for WooCommerce 3.8
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: skyverge, maxrice, tamarazuk, chasewiseman, nekojira, beka.rice
 Tags: woocommerce, product tabs, custom tab, woo commerce tab
 Requires at least: 4.4
 Tested up to: 5.2.4
-Stable tag: 1.7.1
+Stable tag: 1.7.2-dev.1
 
 This plugin extends WooCommerce by allowing a custom product tab to be created with any content.
 

--- a/woocommerce-custom-product-tabs-lite.php
+++ b/woocommerce-custom-product-tabs-lite.php
@@ -5,7 +5,7 @@
  * Description: Extends WooCommerce to add a custom product view page tab
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 1.7.1
+ * Version: 1.7.2-dev.1
  * Tested up to: 5.2.4
  * Text Domain: woocommerce-custom-product-tabs-lite
  * Domain Path: /i18n/languages/
@@ -40,7 +40,7 @@ class WooCommerceCustomProductTabsLite {
 
 
 	/** plugin version number */
-	const VERSION = '1.7.1';
+	const VERSION = '1.7.2-dev.1';
 
 	/** required WooCommerce version number */
 	const MIN_WOOCOMMERCE_VERSION = '3.0.9';

--- a/woocommerce-custom-product-tabs-lite.php
+++ b/woocommerce-custom-product-tabs-lite.php
@@ -10,13 +10,13 @@
  * Text Domain: woocommerce-custom-product-tabs-lite
  * Domain Path: /i18n/languages/
  *
- * Copyright: (c) 2012-2019, SkyVerge, Inc. (info@skyverge.com)
+ * Copyright: (c) 2012-2020, SkyVerge, Inc. (info@skyverge.com)
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
  *
  * @author      SkyVerge
- * @copyright   Copyright (c) 2012-2019, SkyVerge, Inc.
+ * @copyright   Copyright (c) 2012-2020, SkyVerge, Inc. (info@skyverge.com)
  * @license     http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 3.0.9


### PR DESCRIPTION
# Summary

This PR adds support for WooCommerce 3.9 and updates the copyright year to 2020.

### Stories

- [CH 24712](https://app.clubhouse.io/skyverge/story/24712)

## Details

There were no incompatibilities with WC 3.9.

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
