### PR TITLE
WooCommerce 4.1 compatibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,7 @@ add_filter( 'woocommerce_custom_product_tabs_lite_title', 'sv_change_custom_tab_
 == Changelog ==
 
 = 2020.nn.nn - version 1.7.4-dev.1 =
+ * Misc - Add support for WooCommerce 4.1
 
 = 2020.03.10 - version 1.7.3 =
  * Misc - Add support for WooCommerce 4.0

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: skyverge, maxrice, tamarazuk, chasewiseman, nekojira, beka.rice
 Tags: woocommerce, product tabs, custom tab, woo commerce tab
 Requires at least: 4.4
 Tested up to: 5.3.2
-Stable tag: 1.7.3
+Stable tag: 1.7.4-dev.1
 
 This plugin extends WooCommerce by allowing a custom product tab to be created with any content.
 
@@ -79,6 +79,8 @@ add_filter( 'woocommerce_custom_product_tabs_lite_title', 'sv_change_custom_tab_
 `
 
 == Changelog ==
+
+= 2020.nn.nn - version 1.7.4-dev.1 =
 
 = 2020.03.10 - version 1.7.3 =
  * Misc - Add support for WooCommerce 4.0

--- a/woocommerce-custom-product-tabs-lite.php
+++ b/woocommerce-custom-product-tabs-lite.php
@@ -5,7 +5,7 @@
  * Description: Extends WooCommerce to add a custom product view page tab
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 1.7.3
+ * Version: 1.7.4-dev.1
  * Tested up to: 5.3.2
  * Text Domain: woocommerce-custom-product-tabs-lite
  * Domain Path: /i18n/languages/
@@ -40,7 +40,7 @@ class WooCommerceCustomProductTabsLite {
 
 
 	/** plugin version number */
-	const VERSION = '1.7.3';
+	const VERSION = '1.7.4-dev.1';
 
 	/** required WooCommerce version number */
 	const MIN_WOOCOMMERCE_VERSION = '3.0.9';


### PR DESCRIPTION
# Summary

This PR adds support to WC 4.1.

### Story: [CH 53174](https://app.clubhouse.io/skyverge/story/53174/woocommerce-4-1-compatibility)

## Details

There were no incompatibilities with WC 4.1.0-rc.2.

## QA

- [x] Add custom tab in admin
- [x] Display in front end

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version
- [ ] Jilt Promotions has been added