### PR TITLE
Bumps version number to 1.7.5

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,7 @@ This plugin extends WooCommerce by allowing a custom product tab to be created w
 
 This plugin extends [WooCommerce](http://woocommerce.com/) to allow a custom product tab to be added to single product pages with arbitrary content. The new custom tab may contain text, html (such as embedded videos), or shortcodes, and will appear between the "Additional Information" and "Reviews" tabs.
 
-> Requires WooCommerce 3.0.9 or newer
+> Requires WooCommerce 3.9.4 or newer
 
 = Features =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: skyverge, maxrice, tamarazuk, chasewiseman, nekojira, beka.rice
 Tags: woocommerce, product tabs, custom tab, woo commerce tab
 Requires at least: 4.4
 Tested up to: 5.4.1
-Stable tag: 1.7.4
+Stable tag: 1.7.5
 
 This plugin extends WooCommerce by allowing a custom product tab to be created with any content.
 
@@ -79,6 +79,9 @@ add_filter( 'woocommerce_custom_product_tabs_lite_title', 'sv_change_custom_tab_
 `
 
 == Changelog ==
+
+= 2020.05.04 - version 1.7.5 =
+ * Misc - Tests Compatibility with WordPress 5.9.1
 
 = 2020.05.04 - version 1.7.4 =
  * Misc - Add support for WooCommerce 4.1

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: skyverge, maxrice, tamarazuk, chasewiseman, nekojira, beka.rice
 Tags: woocommerce, product tabs, custom tab, woo commerce tab
 Requires at least: 4.4
 Tested up to: 5.4.1
-Stable tag: 1.7.5
+Stable tag: 1.7.5-dev.1
 
 This plugin extends WooCommerce by allowing a custom product tab to be created with any content.
 

--- a/readme.txt
+++ b/readme.txt
@@ -80,8 +80,8 @@ add_filter( 'woocommerce_custom_product_tabs_lite_title', 'sv_change_custom_tab_
 
 == Changelog ==
 
-= 2020.05.04 - version 1.7.5 =
- * Misc - Tests Compatibility with WordPress 5.9.1
+= 2022.nn.nn - version 1.7.5-dev.1 =
+ * Misc - Require WooCommerce 3.9.4 or newer
 
 = 2020.05.04 - version 1.7.4 =
  * Misc - Add support for WooCommerce 4.1

--- a/woocommerce-custom-product-tabs-lite.php
+++ b/woocommerce-custom-product-tabs-lite.php
@@ -10,13 +10,13 @@
  * Text Domain: woocommerce-custom-product-tabs-lite
  * Domain Path: /i18n/languages/
  *
- * Copyright: (c) 2012-2020, SkyVerge, Inc. (info@skyverge.com)
+ * Copyright: (c) 2012-2022, SkyVerge, Inc. (info@skyverge.com)
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
  *
  * @author      SkyVerge
- * @copyright   Copyright (c) 2012-2020, SkyVerge, Inc. (info@skyverge.com)
+ * @copyright   Copyright (c) 2012-2022, SkyVerge, Inc. (info@skyverge.com)
  * @license     http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 3.9.4

--- a/woocommerce-custom-product-tabs-lite.php
+++ b/woocommerce-custom-product-tabs-lite.php
@@ -19,7 +19,7 @@
  * @copyright   Copyright (c) 2012-2020, SkyVerge, Inc. (info@skyverge.com)
  * @license     http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
- * WC requires at least: 3.0.9
+ * WC requires at least: 3.9.4
  * WC tested up to: 4.1.0
  */
 
@@ -43,7 +43,7 @@ class WooCommerceCustomProductTabsLite {
 	const VERSION = '1.7.5-dev.1';
 
 	/** required WooCommerce version number */
-	const MIN_WOOCOMMERCE_VERSION = '3.0.9';
+	const MIN_WOOCOMMERCE_VERSION = '3.9.4';
 
 	/** plugin version name */
 	const VERSION_OPTION_NAME = 'woocommerce_custom_product_tabs_lite_db_version';

--- a/woocommerce-custom-product-tabs-lite.php
+++ b/woocommerce-custom-product-tabs-lite.php
@@ -5,7 +5,7 @@
  * Description: Extends WooCommerce to add a custom product view page tab
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 1.7.4
+ * Version: 1.7.5
  * Tested up to: 5.4.1
  * Text Domain: woocommerce-custom-product-tabs-lite
  * Domain Path: /i18n/languages/
@@ -40,7 +40,7 @@ class WooCommerceCustomProductTabsLite {
 
 
 	/** plugin version number */
-	const VERSION = '1.7.4';
+	const VERSION = '1.7.5';
 
 	/** required WooCommerce version number */
 	const MIN_WOOCOMMERCE_VERSION = '3.0.9';

--- a/woocommerce-custom-product-tabs-lite.php
+++ b/woocommerce-custom-product-tabs-lite.php
@@ -5,7 +5,7 @@
  * Description: Extends WooCommerce to add a custom product view page tab
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 1.7.5
+ * Version: 1.7.5-dev.1
  * Tested up to: 5.4.1
  * Text Domain: woocommerce-custom-product-tabs-lite
  * Domain Path: /i18n/languages/
@@ -40,7 +40,7 @@ class WooCommerceCustomProductTabsLite {
 
 
 	/** plugin version number */
-	const VERSION = '1.7.5';
+	const VERSION = '1.7.5-dev.1';
 
 	/** required WooCommerce version number */
 	const MIN_WOOCOMMERCE_VERSION = '3.0.9';


### PR DESCRIPTION
# Summary <!-- Required -->
Tests and bumps version number to 1.7.5 and compatible with WordPress 5.9.1

### Issue: [MWC-4385](https://jira.godaddy.com/browse/MWC-4385)

## QA <!-- Optional -->
- [ ] Would like to confirm that this is all that's needed for WordPress plugin repo?

## Before merge <!-- Required -->

- [x] This PR makes the appropriate modifications to automated tests or explains why none are needed
- [x] This PR makes the appropriate modifications to documentation or explains why none are needed
- [x] This change does not impact usage or expected outputs of covered code